### PR TITLE
Update bootstrap scripts to handle missing dependencies.

### DIFF
--- a/scripts/bootstrap/bootstrap_maven.sh
+++ b/scripts/bootstrap/bootstrap_maven.sh
@@ -3,7 +3,7 @@
 #
 # Envs
 #
-MAVEN_VERSION=3.5.2
+MAVEN_VERSION=3.5.4
 
 #
 # Download maven if needed

--- a/scripts/bootstrap/bootstrap_os.sh
+++ b/scripts/bootstrap/bootstrap_os.sh
@@ -30,4 +30,4 @@ echo -e "\n##### Installing EPEL Repo"
 yum install -y epel-release
 
 echo -e "\n##### Installing OS packages"
-yum install -y java-1.8.0-openjdk-devel nc git zlib-devel glibc-headers gcc-c++ openssl-devel net-tools links bind-utils jsvc jsoncpp protobuf-devel libgsasl-devel jq
+yum install -y java-1.8.0-openjdk-devel nc git zlib-devel glibc-headers gcc-c++ openssl-devel net-tools links bind-utils jsvc jsoncpp protobuf-devel libgsasl-devel jq wget

--- a/scripts/bootstrap/bootstrap_zookeeper.sh
+++ b/scripts/bootstrap/bootstrap_zookeeper.sh
@@ -3,7 +3,7 @@
 #
 # Env
 #
-ZOOKEEPER_VERSION=3.4.11
+ZOOKEEPER_VERSION=3.4.13
 
 #
 # Download zk tarball


### PR DESCRIPTION
- Install wget
- Bump zookeeper version to 3.4.13 (3.4.11 is no longer available from upstream mirror)
- Bump maven version to 3.5.4 (3.5.2 is no longer vailable from upstream mirror)